### PR TITLE
fix: picker warning inside onchange callback

### DIFF
--- a/components/picker/index.tsx
+++ b/components/picker/index.tsx
@@ -191,7 +191,11 @@ const Picker: React.FC<PickerPropsType> = (props: PickerPropsType) => {
             onCascadeChange(columnIndex);
         }
 
-        setCurrentIndex(columnIndex);
+        // inside callback use setState cause update warning.
+        // add setTimeout avoid setState warning.
+        setTimeout(() => {
+            setCurrentIndex(columnIndex);
+        }, 0);
 
         props.onChange && props.onChange(getColumnChangeValue(0, columnIndex), columnIndex);
     };


### PR DESCRIPTION
#### [Describe]
1. fist load page, touchmove item, console.log warning _Warning: Cannot update a component (`Picker`) while rendering a different component (`PickerColumn`). To locate the bad setState() call inside `PickerColumn`, follow the stack trace as described in https://fb.me/setstate-in-render_

#### [Reason]
son compoment callback to parent can't setState, render can't continue

#### [Solve]
```js
        setTimeout(() => {
            setCurrentIndex(columnIndex);
        }, 0);
```


