### PR TITLE
fix: cascade update options and mul-picker confirm

### DIFF
--- a/components/picker/PickerColumn.tsx
+++ b/components/picker/PickerColumn.tsx
@@ -15,6 +15,7 @@ const [bem] = createNS('picker-column');
 export type DirectionType = 'horizontal' | 'vertical' | '';
 
 export type Props = {
+    index: number;
     valueKey: string;
     allowHtml: boolean;
     className: string;
@@ -23,7 +24,7 @@ export type Props = {
     swipeDuration: number;
     visibleItemCount: number;
     initialOptions: any[];
-    onChange: (index: number) => void;
+    onChange: (index: number, columnIndex: number) => void;
     setColumnChildren: (val: Record<string, unknown>) => void;
 };
 
@@ -41,7 +42,7 @@ export const PickerColumn: React.FC<Props> = (props) => {
         setColumnChildren,
     } = props;
 
-    const options = deepClone(initialOptions);
+    const [options, setOptions] = useState(deepClone(initialOptions));
 
     const [duration, setDuration] = useState(swipeDuration);
 
@@ -77,7 +78,7 @@ export const PickerColumn: React.FC<Props> = (props) => {
                 setCurrentIndex(newIndex);
                 // props callback for get index and value
                 if (emitChange) {
-                    onChange && onChange(newIndex);
+                    onChange && onChange(props.index, newIndex);
                 }
             }
         };
@@ -92,13 +93,9 @@ export const PickerColumn: React.FC<Props> = (props) => {
         setOffset(newOffset);
     }
 
-    // todo: (cascade) how to update options?
-    // function updateOptions(newOptions) {
-    //     if (JSON.stringify(newOptions) !== JSON.stringify(options)) {
-    //         setOptions(deepClone(options));
-    //         setIndex(defaultIndex);
-    //     }
-    // }
+    useEffect(() => {
+        setOptions(deepClone(initialOptions));
+    }, [initialOptions]);
 
     useEffect(() => {
         setColumnChildren({ options, currentIndex });
@@ -227,7 +224,6 @@ export const PickerColumn: React.FC<Props> = (props) => {
 
     const onTouchStart = (event: React.TouchEvent) => {
         resetTouchStatus();
-
         setStartPos({ startX: event.touches[0].clientX, startY: event.touches[0].clientY });
 
         if (moving) {

--- a/components/picker/demo/index.tsx
+++ b/components/picker/demo/index.tsx
@@ -72,6 +72,12 @@ function columns(): any[] {
 }
 
 export default function PickerDemo(): React.ReactElement {
+    const pickerRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        console.log(pickerRef);
+    });
+
     return (
         <View className="demo-picker">
             <DemoBlock title="基础用法">
@@ -79,10 +85,10 @@ export default function PickerDemo(): React.ReactElement {
                     <Picker
                         columns={i18n['zh-CN'].textColumns}
                         showToolbar={true}
-                        onChange={(value: string, index: number) => {
+                        onChange={(value: string | number, index: number | string) => {
                             console.log('demo1 change', value, index);
                         }}
-                        onConfirm={(value: string, index: number) => {
+                        onConfirm={(value: string | number, index: number | string) => {
                             console.log('demo1 confirm', value, index);
                         }}
                         onCancel={() => {
@@ -98,14 +104,24 @@ export default function PickerDemo(): React.ReactElement {
                         columns={i18n['zh-CN'].textColumns}
                         showToolbar={true}
                         title="标题"
-                        defaultIndex="2"
+                        defaultIndex={2}
                     />
                 </div>
             </DemoBlock>
 
             <DemoBlock title="多项选择">
                 <div className="demo-Picker-row">
-                    <Picker columns={i18n['zh-CN'].dateColumns} showToolbar={true} title="标题" />
+                    <Picker
+                        columns={i18n['zh-CN'].dateColumns}
+                        showToolbar={true}
+                        title="标题"
+                        onChange={(value: string | number, index: number | string) => {
+                            console.log('demo1 change', value, index);
+                        }}
+                        onConfirm={(value: string | number, index: number | string) => {
+                            console.log('demo1 confirm', value, index);
+                        }}
+                    />
                 </div>
             </DemoBlock>
 
@@ -132,6 +148,12 @@ export default function PickerDemo(): React.ReactElement {
                         columns={i18n['zh-CN'].cascadeColumns}
                         showToolbar={true}
                         title="标题"
+                        onChange={(value: string | number, index: number | string) => {
+                            console.log('demo1 change', value, index);
+                        }}
+                        onConfirm={(value: string | number, index: number | string) => {
+                            console.log('demo1 confirm', value, index);
+                        }}
                     />
                 </div>
             </DemoBlock>


### PR DESCRIPTION
[descript]
1. cascade change, next options can't update
2. multi picker confirm callback value is null

[solve]

1. record every change crrent options, transform to columnPicker update
2. next options do while
``` ts
     const indexesArray = [];

        while (cursor && cursor.children) {
            const newDefaultIndex: number = isDef(cursor.defaultIndex)
                ? cursor.defaultIndex!
                : +defaultIndex;

            indexesArray.push(newDefaultIndex);

            formatted.push({
                values: cursor.children,
                defaultIndex: newDefaultIndex,
            });

            cursor = cursor.children[newDefaultIndex];
        }

        setIndexes(indexesArray);

        setFormattedColumns(formatted);

        setValues(
            indexesArray.map((item: number, index: number) => formatted[index].values![item].text!),
        );
```


```ts
    useEffect(() => {
        setOptions(deepClone(initialOptions));
    }, [initialOptions]);
```